### PR TITLE
Add initial support for toggling theme

### DIFF
--- a/SolarizedToggle.py
+++ b/SolarizedToggle.py
@@ -31,16 +31,17 @@ class SolarizedToggle(object):
     def set_theme(self):
         light_theme = self.plugin_settings.get("theme_light")
         dark_theme = self.plugin_settings.get("theme_dark")
-        new_theme = light_theme if self.current_mode == "dark" else dark_theme
+        if (light_theme is not None and dark_theme is not None):
+            new_theme = light_theme if self.current_mode == "dark" else dark_theme
 
-        self.global_settings.set("theme", new_theme)
-        sublime.save_settings(self.global_settings_file)
+            self.global_settings.set("theme", new_theme)
+            sublime.save_settings(self.global_settings_file)
 
 class SolarizedToggleCommand(sublime_plugin.ApplicationCommand):
     def run(self, **args):
         _toggler.update_mode()
-        _toggler.set_color_scheme()
         _toggler.set_theme()
+        _toggler.set_color_scheme()
 
 def plugin_loaded():
     _toggler.do_setup()

--- a/SolarizedToggle.sublime-settings
+++ b/SolarizedToggle.sublime-settings
@@ -2,10 +2,13 @@
     // Set color schemes to use. By default the plugin uses Solarized light and dark themes.
     //You can set these to any theme you have installed, whether it's a built-in them or not.
     "color_scheme_light": "Packages/Color Scheme - Default/Solarized (Light).tmTheme",
-    "color_scheme_dark": "Packages/Color Scheme - Default/Solarized (Dark).tmTheme",
-	// Set themes to use. As Sublime Text 2 only comes with one Theme, this is the default
-	// for both light and dark mode.
-    // You can set these to any theme you have installed, whether it's a built-in them or not.
-	"theme_dark": "Default.sublime-theme",
-	"theme_light": "Default.sublime-theme"
+    "color_scheme_dark": "Packages/Color Scheme - Default/Solarized (Dark).tmTheme"
+
+    // Support for Theme switching
+	// As Sublime Text 2 only comes with one Theme, this is disabled by default.
+	// Copy the three lines below to the Solarized Toggle - User settings file to enable it.
+
+    // You can set these to any theme you have installed, whether it's a built-in theme or not.
+	// , "theme_dark": "Default.sublime-theme",
+	// "theme_light": "Default.sublime-theme"
 }


### PR DESCRIPTION
Basic support for switching theme alongside color scheme.

For testing purposes, I've been using Soda Light and Dark, which seem to switch perfectly. In order to keep the scheme and theme in sync, I've add a current_mode field, which is saved in `Packages/User/SolarizedToggle.sublime-settings` to persist across sessions.

One thing to note might be to make sure users are aware that this will overwrite their color scheme and theme settings in `Packages/User/Preferences.sublime-settings`, and they should first update `Packages/User/SolarizedToggle.sublime-settings` to ensure they don't lose their settings. Both in the initial install and the upgrade note.
