### PR TITLE
Change default key to Ctrl+F12

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,5 +1,5 @@
 [
 	{
-		"keys": ["f12"], "command": "solarized_toggle"
+		"keys": ["ctrl+f12"], "command": "solarized_toggle"
 	}
 ]


### PR DESCRIPTION
Key F12 is unused only on Windows. Since Ctrl+F12 is free as well, I suggest to go for control variant on both platforms for better consistency. This fixes https://github.com/damccull/sublimetext-SolarizedToggle/issues/19