### PR TITLE
added support for the BetterFindBuffer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Solarized Toggle
+# Solarized Toggle
 
 ##Introduction
 Solarized Toggle is a very simple plugin originally written to allow users of [Sublime Text 2][st2] and [Sublime Text 3][st3] to easily switch between light and dark versions of the Solarized color scheme.
@@ -8,8 +8,7 @@ Now any color scheme included with Sublime Text or installed separately can be u
 Why use this plugin? Instead of having to manually click Preferences->Color Scheme->Some Colors, you can simply press F12 (CMD+F12 on OSX, Control+F12 on Linux) in order to toggle between two themes. If you enable the theme switcher, you can also easily toggle between themes that compliment your color schemes.
 
 ##New features in this version
-* Linux-specific keybind CTRL-F12 added by https://github.com/lzap.
-* Updated packages.json schema to 3.0.
+* Added support for the [BetterFindBuffer][betterfindbuffer] plugin
 
 ##Contribute to this code:
 * Fork the project, write a patch, submit a pull request.
@@ -44,9 +43,11 @@ Congratulations. The plugin is now installed. Test it by pressing F12 a few time
   * color_scheme
   * font\_face, font\_size, font\_options, (if font switching is enabled)
   * theme (if theme switching is enabled)
+  * find results color scheme (if find results switching is enabled)
 * Prior to Sublime Text 3 build 3114, there is an issue with the theme switcher for both Sublime Text 2 and 3 where the window sometimes does not update the entire theme, leaving some artifacts of the previous theme behind. This is a limitation of Sublime Text itself. To fix the issue, simply resize or minimize/restore your window. This will cause the window to redraw itself with the new theme. Upgrading to a version starting with Sublime Text 3 build 3114 will also fix this problem.
 
 [st2]: http://www.sublimetext.com/ "Sublime Text 2"
 [st3]: http://www.sublimetext.com/3 "Sublime Text 3"
 [packagecontrol]: http://wbond.net/sublime_packages/package_control "Package Control"
 [currentVersion]: https://github.com/damccull/sublimetext-SolarizedToggle/archive/1.4.9.zip "Current Version"
+[betterfindbuffer]: https://packagecontrol.io/packages/BetterFindBuffer "BetterFindBuffer"

--- a/SolarizedToggle.py
+++ b/SolarizedToggle.py
@@ -8,6 +8,8 @@ class SolarizedToggle(object):
         self.global_settings = sublime.load_settings(self.global_settings_file)
         self.plugin_settings_file = 'SolarizedToggle.sublime-settings'
         self.plugin_settings = sublime.load_settings(self.plugin_settings_file)
+        self.find_results_settings_file = 'Find Results.sublime-settings' 
+        self.find_results_settings = sublime.load_settings(self.find_results_settings_file)
 
         ## Determine if active color scheme is one of the toggles        
         # Get the color schemes we want to switch between from the plugin_settings
@@ -43,6 +45,19 @@ class SolarizedToggle(object):
         # Set the color scheme in global_settings and save the global settings file
         self.global_settings.set("color_scheme", new_scheme)
         sublime.save_settings(self.global_settings_file)
+
+    def set_find_results(self):
+        # First get status of theme switching setting from plugin_settings
+        find_results_enabled = self.plugin_settings.get("enable_find_results_switching")
+
+        if (find_results_enabled):
+            
+            # Decide on which scheme to use based on current mode
+            new_scheme = self.light_scheme if self.current_mode == "light" else self.dark_scheme
+
+            # Set the color scheme in find_results_settings and save the find results settings file
+            self.find_results_settings.set("color_scheme", new_scheme)
+            sublime.save_settings(self.find_results_settings_file)
 
     def set_font(self):
         # First get status of theme switching setting from plugin_settings
@@ -95,6 +110,8 @@ class SolarizedToggleCommand(sublime_plugin.ApplicationCommand):
         _toggler.set_font()
         # Set the new color scheme
         _toggler.set_color_scheme()
+        # Set the new find results color scheme
+        _toggler.set_find_results()
 
 def plugin_loaded(): # Called automatically in ST3 only.
     # Run initial setup

--- a/SolarizedToggle.sublime-settings
+++ b/SolarizedToggle.sublime-settings
@@ -36,5 +36,14 @@
     "font_size_dark": 10.0,
     "font_face_light": "Menlo",
     "font_options_light": [ "subpixel_antialias" ],
-    "font_size_light": 11.0
+    "font_size_light": 11.0,
+
+    // Support for the BetterFindBuffer plugin
+    //      To enable: Copy the line below to the Solarized Toggle - User settings file.
+    //                 Change the enable_find_results_switching to true.
+    //                 
+    // NOTE: If you have the Find Results tab open when switching color schemes it won't 
+    // switch. You need to swap to another tab and then return to the Find results tab
+    // for the switch to be successful.
+    "enable_find_results_switching": false,
 }

--- a/messages.json
+++ b/messages.json
@@ -13,5 +13,6 @@
 	"1.4.6": "messages/update-1.4.6.txt",
 	"1.4.7": "messages/update-1.4.7.txt",
 	"1.4.8": "messages/update-1.4.8.txt",
-	"1.4.9": "messages/update-1.4.9.txt"
+	"1.4.9": "messages/update-1.4.9.txt",
+	"1.5.0": "messages/update-1.5.txt"
 }

--- a/messages/update-1.5.txt
+++ b/messages/update-1.5.txt
@@ -1,0 +1,4 @@
+Version 1.5
+
+Changes:
+* Added support for the BetterFindBuffer plugin. https://packagecontrol.io/packages/BetterFindBuffer


### PR DESCRIPTION
First and foremost thanks for making this awesome plugin it's been really useful  👍 

This pr just adds support for the [BetterFindBuffer plugin](https://packagecontrol.io/packages/BetterFindBuffer) because the find results color scheme wasn't updating when I switched themes and it was annoying to change it manually each time I switched themes.